### PR TITLE
fixes runtime configuration of model

### DIFF
--- a/src/memory_agent/utils.ts
+++ b/src/memory_agent/utils.ts
@@ -17,16 +17,16 @@ export function getStoreFromConfigOrThrow(
  */
 export function splitModelAndProvider(fullySpecifiedName: string): {
   model: string;
-  provider?: string;
+  modelProvider?: string;
 } {
-  let provider: string | undefined;
+  let modelProvider: string | undefined;
   let model: string;
 
   if (fullySpecifiedName.includes("/")) {
-    [provider, model] = fullySpecifiedName.split("/", 2);
+    [modelProvider, model] = fullySpecifiedName.split("/", 2);
   } else {
     model = fullySpecifiedName;
   }
 
-  return { model, provider };
+  return { model, modelProvider };
 }


### PR DESCRIPTION
I was trying to use models from Bedrock but could not get it work. Then I found the parameter's name should be. `modelProvider` instead of `provider`: https://github.com/langchain-ai/langchainjs/blob/dfb54dcd0d63603221ff93b1143f2a51c803f777/langchain/src/chat_models/universal.ts#L67-L80