### PR TITLE
chore(ci): test current Node.js LTS versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     name: Integration Tests
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         node-version: [20.x]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,8 +18,8 @@ jobs:
     name: Integration Tests
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        node-version: [20.x]
+        os: [ubuntu-latest]
+        node-version: [22.x, 24.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,8 +19,8 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        node-version: [18.x, 20.x]
+        os: [ubuntu-latest]
+        node-version: [22.x, 24.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         node-version: [18.x, 20.x]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary

- keep CI runners on `ubuntu-latest`
- update unit tests from Node.js 18/20 to Node.js 22/24
- run integration tests on Node.js 22/24

## Test plan

- [x] Parse both workflow files as YAML
- [x] Run `git diff --check`