### PR TITLE
fix(ci): set least-privilege workflow permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
     - cron: "37 14 * * *" # Run at 7:37 AM Pacific Time (14:37 UTC) every day
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another scheduled run starts while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:


### PR DESCRIPTION
## Summary

- set explicit top-level `contents: read` permissions for unit-test CI
- set explicit top-level `contents: read` permissions for scheduled integration tests
- resolves code-scanning alerts #3 and #4 for `actions/missing-workflow-permissions`

## Test plan

- [x] Parsed both workflow files as YAML
- [x] Ran `git diff --check`

Scoped to the two code-scanning findings; no dependency or runtime changes.