### PR TITLE
Update retired default model id claude-3-5-sonnet-20240620

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ We have provided a few example evaluation cases in [the test file here](./tests/
 
 1. Customize memory content: we've defined a simple memory structure `content: string, context: string` for each memory, but you could structure them in other ways.
 2. Provide additional tools: the bot will be more useful if you connect it to other functions.
-3. Select a different model: We default to anthropic/claude-3-5-sonnet-20240620. You can select a compatible chat model using provider/model-name via configuration. Example: openai/gpt-4.
+3. Select a different model: We default to anthropic/claude-sonnet-5. You can select a compatible chat model using provider/model-name via configuration. Example: openai/gpt-4.
 4. Customize the prompts: We provide a default prompt in the [prompts.ts](src/memory_agent/prompts.ts) file. You can easily update this via configuration.
 
 <!--

--- a/src/memory_agent/configuration.ts
+++ b/src/memory_agent/configuration.ts
@@ -15,7 +15,7 @@ export function ensureConfiguration(config?: LangGraphRunnableConfig) {
   const configurable = config?.configurable || {};
   return {
     userId: configurable?.userId || "default",
-    model: configurable?.model || "anthropic/claude-3-5-sonnet-20240620",
+    model: configurable?.model || "anthropic/claude-sonnet-5",
     systemPrompt: configurable?.systemPrompt || SYSTEM_PROMPT,
   };
 }


### PR DESCRIPTION
The agent's default model is `anthropic/claude-3-5-sonnet-20240620`, which Anthropic retired on 21 July 2025 ([model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations)). Anyone who clones this template and runs it without setting `model` in the config gets that id sent to the API.

| File | Line | Before | After |
| --- | --- | --- | --- |
| `src/memory_agent/configuration.ts` | 18 | `anthropic/claude-3-5-sonnet-20240620` | `anthropic/claude-sonnet-5` |
| `README.md` | 88 | same id in the "Select a different model" note | `anthropic/claude-sonnet-5` |

Two things I left alone on purpose. The `### Setup Model` block and the config schema block further down in the README both carry a `DO NOT EDIT MANUALLY` marker and say they come from `langgraph template lock`, so the id in them should change when that command is re-run rather than by hand. The model list inside that schema also still offers `claude-2.0`, `claude-2.1`, `claude-instant-1.2` and the Claude 3 family, all retired, which is the same regeneration question.

`initChatModel` is called in `src/memory_agent/graph.ts` with no `temperature`, `top_p` or `top_k`, so nothing else needs adjusting for the newer model.

I have not run this against the API to reproduce a failure. The claim rests on the published retirement date.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
